### PR TITLE
Make commands for gcc and llvm-gcc version agnostic

### DIFF
--- a/runcocoa.sh
+++ b/runcocoa.sh
@@ -60,13 +60,13 @@ fi
 if [ "$ios" ]; then
     export MACOSX_DEPLOYMENT_TARGET=10.6
     export PATH="/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin:/Developer/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-    gcc="/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin/llvm-gcc-4.2 \
+    gcc="/usr/bin/env llvm-gcc \
                 -x objective-c -arch i386 -fmessage-length=0 -pipe -std=c99 -fpascal-strings -O0 \
                 -isysroot /Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator4.2.sdk -fexceptions -fasm-blocks \
                 -mmacosx-version-min=10.6 -gdwarf-2 -fvisibility=hidden -fobjc-abi-version=2 -fobjc-legacy-dispatch -D__IPHONE_OS_VERSION_MIN_REQUIRED=40000 \
                 -Xlinker -objc_abi_version -Xlinker 2 -framework Foundation -framework UIKit -framework CoreGraphics -framework CoreText";
 else
-    gcc="/Developer/usr/bin/gcc-4.2 -O0 -framework Foundation -framework Cocoa";
+    gcc="/usr/bin/env gcc -O0 -framework Foundation -framework Cocoa";
 fi
 
 if ! $gcc /tmp/runcocoa.m $ccflags -o /tmp/runcocoa-output; then


### PR DESCRIPTION
Use /usr/bin/env gcc instead. This way, the script continues to work
after an upgrade of either gcc or llvm-gcc

Something similar should be possible for the ios sdk
